### PR TITLE
Add Vault component for secure secret storage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,35 +121,6 @@ This roadmap outlines planned libraries and updates for the Sons of PHP monorepo
     - Release notes highlight Symfony 7 support.
     - Implementation meets the Global DoD.
 
-### Epic: Introduce Vault Component
-**Description:** Provide secure secret storage with pluggable backends.
-
-- [ ] Add filesystem storage adapter.
-  - **Acceptance Criteria**
-    - All Global DoR items are satisfied before implementation begins.
-    - Filesystem adapter encrypts and retrieves secrets reliably.
-    - Implementation meets the Global DoD.
-- [ ] Add database storage adapter.
-  - **Acceptance Criteria**
-    - All Global DoR items are satisfied before implementation begins.
-    - Database adapter persists encrypted secrets.
-    - Implementation meets the Global DoD.
-- [ ] Add Redis storage adapter.
-  - **Acceptance Criteria**
-    - All Global DoR items are satisfied before implementation begins.
-    - Redis adapter stores encrypted secrets and respects expirations.
-    - Implementation meets the Global DoD.
-- [ ] Support key rotation and secret versioning.
-  - **Acceptance Criteria**
-    - All Global DoR items are satisfied before implementation begins.
-    - Secrets can be rotated without loss using new keys.
-    - Implementation meets the Global DoD.
-- [ ] Provide CLI tools for managing secrets.
-  - **Acceptance Criteria**
-    - All Global DoR items are satisfied before implementation begins.
-    - CLI allows setting, retrieving, and rotating secrets.
-    - Implementation meets the Global DoD.
-
 ## Suggestions
 
 - Automate dependency updates with a scheduled tool (e.g., Renovate or Dependabot).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,6 +121,35 @@ This roadmap outlines planned libraries and updates for the Sons of PHP monorepo
     - Release notes highlight Symfony 7 support.
     - Implementation meets the Global DoD.
 
+### Epic: Introduce Vault Component
+**Description:** Provide secure secret storage with pluggable backends.
+
+- [ ] Add filesystem storage adapter.
+  - **Acceptance Criteria**
+    - All Global DoR items are satisfied before implementation begins.
+    - Filesystem adapter encrypts and retrieves secrets reliably.
+    - Implementation meets the Global DoD.
+- [ ] Add database storage adapter.
+  - **Acceptance Criteria**
+    - All Global DoR items are satisfied before implementation begins.
+    - Database adapter persists encrypted secrets.
+    - Implementation meets the Global DoD.
+- [ ] Add Redis storage adapter.
+  - **Acceptance Criteria**
+    - All Global DoR items are satisfied before implementation begins.
+    - Redis adapter stores encrypted secrets and respects expirations.
+    - Implementation meets the Global DoD.
+- [ ] Support key rotation and secret versioning.
+  - **Acceptance Criteria**
+    - All Global DoR items are satisfied before implementation begins.
+    - Secrets can be rotated without loss using new keys.
+    - Implementation meets the Global DoD.
+- [ ] Provide CLI tools for managing secrets.
+  - **Acceptance Criteria**
+    - All Global DoR items are satisfied before implementation begins.
+    - CLI allows setting, retrieving, and rotating secrets.
+    - Implementation meets the Global DoD.
+
 ## Suggestions
 
 - Automate dependency updates with a scheduled tool (e.g., Renovate or Dependabot).

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "sonsofphp/pager-implementation": "0.3.x-dev",
         "sonsofphp/registry-implementation": "0.3.x-dev",
         "sonsofphp/state-machine-implementation": "0.3.x-dev",
+        "sonsofphp/vault-implementation": "0.3.x-dev",
         "sonsofphp/version-implementation": "0.3.x-dev"
     },
     "require": {
@@ -136,6 +137,7 @@
         "sonsofphp/registry-contract": "self.version",
         "sonsofphp/state-machine": "self.version",
         "sonsofphp/state-machine-contract": "self.version",
+        "sonsofphp/vault": "self.version",
         "sonsofphp/version": "self.version",
         "sonsofphp/version-contract": "self.version"
     },
@@ -172,7 +174,8 @@
             "src/SonsOfPHP/Bridge/Doctrine/DBAL/Pager/Tests",
             "src/SonsOfPHP/Bridge/Doctrine/ORM/Pager/Tests",
             "src/SonsOfPHP/Component/Version/Tests",
-            "src/SonsOfPHP/Component/Registry/Tests"
+            "src/SonsOfPHP/Component/Registry/Tests",
+            "src/SonsOfPHP/Component/Vault/Tests"
         ],
         "psr-4": {
             "SonsOfPHP\\Bard\\": "src/SonsOfPHP/Bard/src",
@@ -206,6 +209,7 @@
             "SonsOfPHP\\Component\\Pager\\": "src/SonsOfPHP/Component/Pager",
             "SonsOfPHP\\Component\\Registry\\": "src/SonsOfPHP/Component/Registry",
             "SonsOfPHP\\Component\\StateMachine\\": "src/SonsOfPHP/Component/StateMachine",
+            "SonsOfPHP\\Component\\Vault\\": "src/SonsOfPHP/Component/Vault",
             "SonsOfPHP\\Component\\Version\\": "src/SonsOfPHP/Component/Version",
             "SonsOfPHP\\Contract\\Common\\": "src/SonsOfPHP/Contract/Common",
             "SonsOfPHP\\Contract\\Cookie\\": "src/SonsOfPHP/Contract/Cookie",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -74,6 +74,7 @@
   * [Adapters](components/pager/adapters.md)
 * [Registry](components/registry.md)
 * [State Machine](components/state-machine.md)
+* [Vault](components/vault.md)
 * [Version](components/version.md)
 
 ## 💁 Contributing

--- a/docs/components/vault.md
+++ b/docs/components/vault.md
@@ -1,28 +1,62 @@
 # Vault
 
-The Vault component securely stores secrets using pluggable storage backends and encryption with key rotation and support for additional authenticated data (AAD).
+The Vault component securely stores secrets using pluggable storage backends and encryption with key rotation, versioning, and additional authenticated data (AAD).
 
-## Basic Usage
+## Setup
 
 ```php
 use SonsOfPHP\Component\Vault\Cipher\OpenSSLCipher;
 use SonsOfPHP\Component\Vault\KeyRing\InMemoryKeyRing;
+use SonsOfPHP\Component\Vault\Marshaller\JsonMarshaller;
 use SonsOfPHP\Component\Vault\Storage\InMemoryStorage;
 use SonsOfPHP\Component\Vault\Vault;
 
-$keyRing = new InMemoryKeyRing(['v1' => '32_byte_master_key_example!!'], 'v1');
-$vault   = new Vault(new InMemoryStorage(), new OpenSSLCipher(), $keyRing);
-$vault->set('db_password', 'secret', ['app']);
-$secret = $vault->get('db_password', ['app']);
+$storage    = new InMemoryStorage();
+$cipher     = new OpenSSLCipher();
+$keyRing    = new InMemoryKeyRing(['v1' => '32_byte_master_key_example!!'], 'v1');
+$marshaller = new JsonMarshaller();
+$vault      = new Vault($storage, $cipher, $keyRing, $marshaller);
+```
 
-// Store a new version of the secret
-$vault->set('db_password', 'new-secret', ['app']);
-$oldSecret = $vault->get('db_password', ['app'], 1); // retrieve version 1
+## Storing and Retrieving Secrets
 
-// Rotate the master key
+```php
+$vault->set('db_password', 'secret');
+$secret = $vault->get('db_password');
+```
+
+## Using Additional Authenticated Data
+
+```php
+$vault->set('token', 'secret', ['app']);
+$secret = $vault->get('token', ['app']);
+```
+
+## Versioned Secrets
+
+```php
+$vault->set('db_password', 'old-secret');
+$vault->set('db_password', 'new-secret');
+
+// Retrieve specific version
+$old = $vault->get('db_password', [], 1);
+```
+
+## Rotating Keys
+
+```php
 $vault->rotateKey('v2', 'another_32_byte_master_key!!');
+```
 
-// Store non-string data
+Secrets encrypted with previous keys remain accessible because the key ring keeps old keys.
+
+## Storing Non-String Data
+
+```php
 $vault->set('config', ['user' => 'root']);
 $config = $vault->get('config');
 ```
+
+## Custom Marshallers
+
+Vault uses a marshaller to convert secrets to strings before encryption. The default `JsonMarshaller` handles arrays and scalars, but you can provide your own implementation of `MarshallerInterface` for advanced use cases.

--- a/docs/components/vault.md
+++ b/docs/components/vault.md
@@ -1,0 +1,15 @@
+# Vault
+
+The Vault component securely stores secrets using pluggable storage backends and encryption.
+
+## Basic Usage
+
+```php
+use SonsOfPHP\Component\Vault\Cipher\OpenSSLCipher;
+use SonsOfPHP\Component\Vault\Storage\InMemoryStorage;
+use SonsOfPHP\Component\Vault\Vault;
+
+$vault = new Vault(new InMemoryStorage(), new OpenSSLCipher(), 'encryption-key');
+$vault->set('db_password', 'secret');
+$secret = $vault->get('db_password');
+```

--- a/docs/components/vault.md
+++ b/docs/components/vault.md
@@ -1,6 +1,6 @@
 # Vault
 
-The Vault component securely stores secrets using pluggable storage backends and encryption.
+The Vault component securely stores secrets using pluggable storage backends and encryption with key rotation and support for additional authenticated data (AAD).
 
 ## Basic Usage
 
@@ -9,7 +9,15 @@ use SonsOfPHP\Component\Vault\Cipher\OpenSSLCipher;
 use SonsOfPHP\Component\Vault\Storage\InMemoryStorage;
 use SonsOfPHP\Component\Vault\Vault;
 
-$vault = new Vault(new InMemoryStorage(), new OpenSSLCipher(), 'encryption-key');
-$vault->set('db_password', 'secret');
-$secret = $vault->get('db_password');
+$keys  = ['v1' => '32_byte_master_key_example!!'];
+$vault = new Vault(new InMemoryStorage(), new OpenSSLCipher(), $keys, 'v1');
+$vault->set('db_password', 'secret', 'app');
+$secret = $vault->get('db_password', 'app');
+
+// Rotate the master key
+$vault->rotateKey('v2', 'another_32_byte_master_key!!');
+
+// Store non-string data
+$vault->set('config', ['user' => 'root']);
+$config = $vault->get('config');
 ```

--- a/docs/components/vault.md
+++ b/docs/components/vault.md
@@ -6,13 +6,18 @@ The Vault component securely stores secrets using pluggable storage backends and
 
 ```php
 use SonsOfPHP\Component\Vault\Cipher\OpenSSLCipher;
+use SonsOfPHP\Component\Vault\KeyRing\InMemoryKeyRing;
 use SonsOfPHP\Component\Vault\Storage\InMemoryStorage;
 use SonsOfPHP\Component\Vault\Vault;
 
-$keys  = ['v1' => '32_byte_master_key_example!!'];
-$vault = new Vault(new InMemoryStorage(), new OpenSSLCipher(), $keys, 'v1');
-$vault->set('db_password', 'secret', 'app');
-$secret = $vault->get('db_password', 'app');
+$keyRing = new InMemoryKeyRing(['v1' => '32_byte_master_key_example!!'], 'v1');
+$vault   = new Vault(new InMemoryStorage(), new OpenSSLCipher(), $keyRing);
+$vault->set('db_password', 'secret', ['app']);
+$secret = $vault->get('db_password', ['app']);
+
+// Store a new version of the secret
+$vault->set('db_password', 'new-secret', ['app']);
+$oldSecret = $vault->get('db_password', ['app'], 1); // retrieve version 1
 
 // Rotate the master key
 $vault->rotateKey('v2', 'another_32_byte_master_key!!');

--- a/src/SonsOfPHP/Component/Vault/AGENTS.md
+++ b/src/SonsOfPHP/Component/Vault/AGENTS.md
@@ -1,0 +1,14 @@
+# Agents Guide for Package: src/SonsOfPHP/Component/Vault
+
+## Scope
+
+- Source: `src/SonsOfPHP/Component/Vault`
+- Tests: `src/SonsOfPHP/Component/Vault/Tests`
+- Do not edit: any `vendor/` directories
+
+## Workflows
+
+- Install once at repo root: `make install`
+- Test this package only: `PHPUNIT_OPTIONS='src/SonsOfPHP/Component/Vault/Tests' make test`
+- Style and static analysis: `make php-cs-fixer` and `make psalm`
+- Upgrade code (may modify files): `make upgrade-code`

--- a/src/SonsOfPHP/Component/Vault/AGENTS.md
+++ b/src/SonsOfPHP/Component/Vault/AGENTS.md
@@ -12,3 +12,13 @@
 - Test this package only: `PHPUNIT_OPTIONS='src/SonsOfPHP/Component/Vault/Tests' make test`
 - Style and static analysis: `make php-cs-fixer` and `make psalm`
 - Upgrade code (may modify files): `make upgrade-code`
+
+## Testing Guidelines
+
+- Use PHPUnit attributes such as `#[CoversClass]` for coverage.
+- Each test method should verify a single behavior.
+
+## Component Notes
+
+- Secrets are marshalled using implementations of `MarshallerInterface`.
+- Prefer domain-specific exceptions under `Exception/` when reporting errors.

--- a/src/SonsOfPHP/Component/Vault/Cipher/CipherInterface.php
+++ b/src/SonsOfPHP/Component/Vault/Cipher/CipherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Cipher;
+
+/**
+ * Defines methods for encrypting and decrypting secrets.
+ */
+interface CipherInterface
+{
+    /**
+     * Encrypts plaintext using the provided key.
+     */
+    public function encrypt(string $plaintext, string $key): string;
+
+    /**
+     * Decrypts ciphertext using the provided key.
+     */
+    public function decrypt(string $ciphertext, string $key): string;
+}

--- a/src/SonsOfPHP/Component/Vault/Cipher/CipherInterface.php
+++ b/src/SonsOfPHP/Component/Vault/Cipher/CipherInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SonsOfPHP\Component\Vault\Cipher;
 
+use SensitiveParameter;
+
 /**
  * Defines methods for encrypting and decrypting secrets.
  */
@@ -11,11 +13,15 @@ interface CipherInterface
 {
     /**
      * Encrypts plaintext using the provided key and optional authenticated data.
+     *
+     * @param array<array-key, mixed> $aad Additional authenticated data.
      */
-    public function encrypt(string $plaintext, string $key, string $aad = ''): string;
+    public function encrypt(#[SensitiveParameter] string $plaintext, #[SensitiveParameter] string $key, array $aad = []): string;
 
     /**
      * Decrypts ciphertext using the provided key and optional authenticated data.
+     *
+     * @param array<array-key, mixed> $aad Additional authenticated data.
      */
-    public function decrypt(string $ciphertext, string $key, string $aad = ''): string;
+    public function decrypt(#[SensitiveParameter] string $ciphertext, #[SensitiveParameter] string $key, array $aad = []): string;
 }

--- a/src/SonsOfPHP/Component/Vault/Cipher/CipherInterface.php
+++ b/src/SonsOfPHP/Component/Vault/Cipher/CipherInterface.php
@@ -10,12 +10,12 @@ namespace SonsOfPHP\Component\Vault\Cipher;
 interface CipherInterface
 {
     /**
-     * Encrypts plaintext using the provided key.
+     * Encrypts plaintext using the provided key and optional authenticated data.
      */
-    public function encrypt(string $plaintext, string $key): string;
+    public function encrypt(string $plaintext, string $key, string $aad = ''): string;
 
     /**
-     * Decrypts ciphertext using the provided key.
+     * Decrypts ciphertext using the provided key and optional authenticated data.
      */
-    public function decrypt(string $ciphertext, string $key): string;
+    public function decrypt(string $ciphertext, string $key, string $aad = ''): string;
 }

--- a/src/SonsOfPHP/Component/Vault/Cipher/OpenSSLCipher.php
+++ b/src/SonsOfPHP/Component/Vault/Cipher/OpenSSLCipher.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Cipher;
+
+use RuntimeException;
+
+/**
+ * Encrypts and decrypts secrets using OpenSSL.
+ */
+class OpenSSLCipher implements CipherInterface
+{
+    public function __construct(private readonly string $cipherMethod = 'aes-256-ctr')
+    {
+    }
+
+    public function encrypt(string $plaintext, string $key): string
+    {
+        $ivLength = openssl_cipher_iv_length($this->cipherMethod);
+        $iv       = random_bytes($ivLength);
+        $encrypted = openssl_encrypt($plaintext, $this->cipherMethod, $key, OPENSSL_RAW_DATA, $iv);
+        if (false === $encrypted) {
+            throw new RuntimeException('Unable to encrypt secret.');
+        }
+
+        return base64_encode($iv . $encrypted);
+    }
+
+    public function decrypt(string $ciphertext, string $key): string
+    {
+        $data     = base64_decode($ciphertext, true);
+        $ivLength = openssl_cipher_iv_length($this->cipherMethod);
+        $iv       = substr($data, 0, $ivLength);
+        $payload  = substr($data, $ivLength);
+        $decrypted = openssl_decrypt($payload, $this->cipherMethod, $key, OPENSSL_RAW_DATA, $iv);
+        if (false === $decrypted) {
+            throw new RuntimeException('Unable to decrypt secret.');
+        }
+
+        return $decrypted;
+    }
+}

--- a/src/SonsOfPHP/Component/Vault/Cipher/OpenSSLCipher.php
+++ b/src/SonsOfPHP/Component/Vault/Cipher/OpenSSLCipher.php
@@ -11,29 +11,37 @@ use RuntimeException;
  */
 class OpenSSLCipher implements CipherInterface
 {
-    public function __construct(private readonly string $cipherMethod = 'aes-256-ctr')
-    {
-    }
+    /**
+     * @param string $cipherMethod OpenSSL cipher method supporting AEAD.
+     */
+    public function __construct(private readonly string $cipherMethod = 'aes-256-gcm') {}
 
-    public function encrypt(string $plaintext, string $key): string
+    public function encrypt(string $plaintext, string $key, string $aad = ''): string
     {
         $ivLength = openssl_cipher_iv_length($this->cipherMethod);
         $iv       = random_bytes($ivLength);
-        $encrypted = openssl_encrypt($plaintext, $this->cipherMethod, $key, OPENSSL_RAW_DATA, $iv);
+        $tag      = '';
+        $encrypted = openssl_encrypt($plaintext, $this->cipherMethod, $key, OPENSSL_RAW_DATA, $iv, $tag, $aad, 16);
         if (false === $encrypted) {
             throw new RuntimeException('Unable to encrypt secret.');
         }
 
-        return base64_encode($iv . $encrypted);
+        return base64_encode($iv . $tag . $encrypted);
     }
 
-    public function decrypt(string $ciphertext, string $key): string
+    public function decrypt(string $ciphertext, string $key, string $aad = ''): string
     {
-        $data     = base64_decode($ciphertext, true);
-        $ivLength = openssl_cipher_iv_length($this->cipherMethod);
-        $iv       = substr($data, 0, $ivLength);
-        $payload  = substr($data, $ivLength);
-        $decrypted = openssl_decrypt($payload, $this->cipherMethod, $key, OPENSSL_RAW_DATA, $iv);
+        $data = base64_decode($ciphertext, true);
+        if (false === $data) {
+            throw new RuntimeException('Invalid ciphertext.');
+        }
+
+        $ivLength  = openssl_cipher_iv_length($this->cipherMethod);
+        $tagLength = 16;
+        $iv        = substr($data, 0, $ivLength);
+        $tag       = substr($data, $ivLength, $tagLength);
+        $payload   = substr($data, $ivLength + $tagLength);
+        $decrypted = openssl_decrypt($payload, $this->cipherMethod, $key, OPENSSL_RAW_DATA, $iv, $tag, $aad);
         if (false === $decrypted) {
             throw new RuntimeException('Unable to decrypt secret.');
         }

--- a/src/SonsOfPHP/Component/Vault/Exception/CipherException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/CipherException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Base exception for cipher related failures.
+ */
+class CipherException extends VaultException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/DecryptionFailedException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/DecryptionFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Thrown when a value cannot be decrypted.
+ */
+class DecryptionFailedException extends CipherException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/EncryptionFailedException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/EncryptionFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Thrown when a value cannot be encrypted.
+ */
+class EncryptionFailedException extends CipherException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/InvalidCiphertextException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/InvalidCiphertextException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Thrown when ciphertext cannot be decoded before decryption.
+ */
+class InvalidCiphertextException extends CipherException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/MarshallingException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/MarshallingException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Thrown when marshalling or unmarshalling secret data fails.
+ */
+class MarshallingException extends VaultException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/SecretStorageCorruptedException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/SecretStorageCorruptedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Thrown when the stored secret data is malformed or corrupted.
+ */
+class SecretStorageCorruptedException extends VaultException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/UnknownKeyException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/UnknownKeyException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+/**
+ * Thrown when a key cannot be found in the key ring.
+ */
+class UnknownKeyException extends VaultException {}

--- a/src/SonsOfPHP/Component/Vault/Exception/VaultException.php
+++ b/src/SonsOfPHP/Component/Vault/Exception/VaultException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Exception;
+
+use RuntimeException;
+
+/**
+ * Base exception for the Vault component.
+ */
+class VaultException extends RuntimeException {}

--- a/src/SonsOfPHP/Component/Vault/KeyRing/InMemoryKeyRing.php
+++ b/src/SonsOfPHP/Component/Vault/KeyRing/InMemoryKeyRing.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\KeyRing;
+
+use SensitiveParameter;
+
+/**
+ * Simple key ring that keeps keys in memory.
+ */
+class InMemoryKeyRing implements KeyRingInterface
+{
+    /**
+     * @param array<string, string> $keys Map of key IDs to keys.
+     * @param string                $currentKeyId Identifier of the active key.
+     */
+    public function __construct(private array $keys, private string $currentKeyId) {}
+
+    public function getCurrentKeyId(): string
+    {
+        return $this->currentKeyId;
+    }
+
+    public function getCurrentKey(): string
+    {
+        return $this->keys[$this->currentKeyId];
+    }
+
+    public function getKey(string $keyId): ?string
+    {
+        return $this->keys[$keyId] ?? null;
+    }
+
+    public function rotate(string $keyId, #[SensitiveParameter] string $key): void
+    {
+        $this->keys[$keyId] = $key;
+        $this->currentKeyId = $keyId;
+    }
+}

--- a/src/SonsOfPHP/Component/Vault/KeyRing/KeyRingInterface.php
+++ b/src/SonsOfPHP/Component/Vault/KeyRing/KeyRingInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\KeyRing;
+
+use SensitiveParameter;
+
+/**
+ * Manages encryption keys and their versions.
+ */
+interface KeyRingInterface
+{
+    /**
+     * Returns the identifier for the current key.
+     */
+    public function getCurrentKeyId(): string;
+
+    /**
+     * Returns the current encryption key.
+     */
+    public function getCurrentKey(): string;
+
+    /**
+     * Fetches a key by its identifier or null if missing.
+     */
+    public function getKey(string $keyId): ?string;
+
+    /**
+     * Rotates to a new key and sets it as current.
+     */
+    public function rotate(string $keyId, #[SensitiveParameter] string $key): void;
+}

--- a/src/SonsOfPHP/Component/Vault/LICENSE
+++ b/src/SonsOfPHP/Component/Vault/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 to Present Joshua Estes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SonsOfPHP/Component/Vault/Marshaller/JsonMarshaller.php
+++ b/src/SonsOfPHP/Component/Vault/Marshaller/JsonMarshaller.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Marshaller;
+
+use JsonException;
+use SonsOfPHP\Component\Vault\Exception\MarshallingException;
+
+/**
+ * Serializes values using JSON.
+ */
+final class JsonMarshaller implements MarshallerInterface
+{
+    public function marshall(mixed $value): string
+    {
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw new MarshallingException('Unable to encode value.', 0, $jsonException);
+        }
+    }
+
+    public function unmarshall(string $value): mixed
+    {
+        try {
+            return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw new MarshallingException('Unable to decode value.', 0, $jsonException);
+        }
+    }
+}

--- a/src/SonsOfPHP/Component/Vault/Marshaller/MarshallerInterface.php
+++ b/src/SonsOfPHP/Component/Vault/Marshaller/MarshallerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Marshaller;
+
+use SonsOfPHP\Component\Vault\Exception\MarshallingException;
+
+/**
+ * Marshals PHP values to and from storable strings.
+ */
+interface MarshallerInterface
+{
+    /**
+     * Converts a PHP value to a string for storage.
+     */
+    public function marshall(mixed $value): string;
+
+    /**
+     * Restores a PHP value from stored data.
+     *
+     * @throws MarshallingException
+     */
+    public function unmarshall(string $value): mixed;
+}

--- a/src/SonsOfPHP/Component/Vault/README.md
+++ b/src/SonsOfPHP/Component/Vault/README.md
@@ -1,7 +1,7 @@
 Sons of PHP - Vault
 ===================
 
-Secure secret storage with pluggable backends, key rotation, and support for additional authenticated data.
+Secure secret storage with pluggable backends, key rotation, secret versioning, and support for additional authenticated data.
 
 ## Learn More
 

--- a/src/SonsOfPHP/Component/Vault/README.md
+++ b/src/SonsOfPHP/Component/Vault/README.md
@@ -1,6 +1,8 @@
 Sons of PHP - Vault
 ===================
 
+Secure secret storage with pluggable backends, key rotation, and support for additional authenticated data.
+
 ## Learn More
 
 * [Documentation][docs]

--- a/src/SonsOfPHP/Component/Vault/README.md
+++ b/src/SonsOfPHP/Component/Vault/README.md
@@ -1,0 +1,16 @@
+Sons of PHP - Vault
+===================
+
+## Learn More
+
+* [Documentation][docs]
+* [Contributing][contributing]
+* [Report Issues][issues] and [Submit Pull Requests][pull-requests] in the [Mother Repository][mother-repo]
+* Get Help & Support using [Discussions][discussions]
+
+[discussions]: https://github.com/orgs/SonsOfPHP/discussions
+[mother-repo]: https://github.com/SonsOfPHP/sonsofphp
+[contributing]: https://docs.sonsofphp.com/contributing/
+[docs]: https://docs.sonsofphp.com/components/vault/
+[issues]: https://github.com/SonsOfPHP/sonsofphp/issues?q=is%3Aopen+is%3Aissue+label%3AVault
+[pull-requests]: https://github.com/SonsOfPHP/sonsofphp/pulls?q=is%3Aopen+is%3Apr+label%3AVault

--- a/src/SonsOfPHP/Component/Vault/README.md
+++ b/src/SonsOfPHP/Component/Vault/README.md
@@ -1,7 +1,7 @@
 Sons of PHP - Vault
 ===================
 
-Secure secret storage with pluggable backends, key rotation, secret versioning, and support for additional authenticated data.
+Secure secret storage with pluggable backends, key rotation, secret versioning, customizable marshallers, and support for additional authenticated data.
 
 ## Learn More
 

--- a/src/SonsOfPHP/Component/Vault/ROADMAP.md
+++ b/src/SonsOfPHP/Component/Vault/ROADMAP.md
@@ -29,3 +29,10 @@
   - All Global DoR items are satisfied before implementation begins.
   - CLI allows basic secret management tasks.
   - Implementation meets the Global DoD.
+
+### Add Symfony Serializer marshaller
+- [ ] Support complex object graphs using Symfony's Serializer component.
+- **Acceptance Criteria**
+  - All Global DoR items are satisfied before implementation begins.
+  - Marshaller encodes and decodes objects using Symfony Serializer.
+  - Implementation meets the Global DoD.

--- a/src/SonsOfPHP/Component/Vault/ROADMAP.md
+++ b/src/SonsOfPHP/Component/Vault/ROADMAP.md
@@ -23,11 +23,11 @@
   - Redis adapter encrypts secrets and handles expirations.
   - Implementation meets the Global DoD.
 
-### Support key rotation and secret versioning
-- [ ] Provide APIs to rotate encryption keys and maintain secret history.
+### Add secret versioning
+- [ ] Provide APIs to maintain secret history across updates.
 - **Acceptance Criteria**
   - All Global DoR items are satisfied before implementation begins.
-  - Secrets can be re-encrypted with new keys without loss.
+  - Previous versions of a secret remain accessible.
   - Implementation meets the Global DoD.
 
 ### Provide CLI tools for managing secrets

--- a/src/SonsOfPHP/Component/Vault/ROADMAP.md
+++ b/src/SonsOfPHP/Component/Vault/ROADMAP.md
@@ -1,0 +1,38 @@
+# Vault Component Roadmap
+
+## Upcoming Features
+
+### Add filesystem storage adapter
+- [ ] Implementation uses encrypted files to persist secrets.
+- **Acceptance Criteria**
+  - All Global DoR items are satisfied before implementation begins.
+  - Filesystem adapter securely reads and writes secrets.
+  - Implementation meets the Global DoD.
+
+### Add database storage adapter
+- [ ] Store secrets in a relational database using PDO.
+- **Acceptance Criteria**
+  - All Global DoR items are satisfied before implementation begins.
+  - Secrets are encrypted before storage.
+  - Implementation meets the Global DoD.
+
+### Add Redis storage adapter
+- [ ] Store secrets in Redis for fast access.
+- **Acceptance Criteria**
+  - All Global DoR items are satisfied before implementation begins.
+  - Redis adapter encrypts secrets and handles expirations.
+  - Implementation meets the Global DoD.
+
+### Support key rotation and secret versioning
+- [ ] Provide APIs to rotate encryption keys and maintain secret history.
+- **Acceptance Criteria**
+  - All Global DoR items are satisfied before implementation begins.
+  - Secrets can be re-encrypted with new keys without loss.
+  - Implementation meets the Global DoD.
+
+### Provide CLI tools for managing secrets
+- [ ] Expose commands to set, get, and rotate secrets.
+- **Acceptance Criteria**
+  - All Global DoR items are satisfied before implementation begins.
+  - CLI allows basic secret management tasks.
+  - Implementation meets the Global DoD.

--- a/src/SonsOfPHP/Component/Vault/ROADMAP.md
+++ b/src/SonsOfPHP/Component/Vault/ROADMAP.md
@@ -23,13 +23,6 @@
   - Redis adapter encrypts secrets and handles expirations.
   - Implementation meets the Global DoD.
 
-### Add secret versioning
-- [ ] Provide APIs to maintain secret history across updates.
-- **Acceptance Criteria**
-  - All Global DoR items are satisfied before implementation begins.
-  - Previous versions of a secret remain accessible.
-  - Implementation meets the Global DoD.
-
 ### Provide CLI tools for managing secrets
 - [ ] Expose commands to set, get, and rotate secrets.
 - **Acceptance Criteria**

--- a/src/SonsOfPHP/Component/Vault/Storage/InMemoryStorage.php
+++ b/src/SonsOfPHP/Component/Vault/Storage/InMemoryStorage.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Storage;
+
+/**
+ * Simple in-memory storage for secrets.
+ */
+class InMemoryStorage implements StorageInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $secrets = [];
+
+    public function set(string $name, string $value): void
+    {
+        $this->secrets[$name] = $value;
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->secrets[$name] ?? null;
+    }
+
+    public function delete(string $name): void
+    {
+        unset($this->secrets[$name]);
+    }
+}

--- a/src/SonsOfPHP/Component/Vault/Storage/StorageInterface.php
+++ b/src/SonsOfPHP/Component/Vault/Storage/StorageInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Storage;
+
+/**
+ * Defines methods for persisting secrets.
+ */
+interface StorageInterface
+{
+    /**
+     * Stores an encrypted secret.
+     */
+    public function set(string $name, string $value): void;
+
+    /**
+     * Retrieves an encrypted secret or null if it does not exist.
+     */
+    public function get(string $name): ?string;
+
+    /**
+     * Deletes a secret.
+     */
+    public function delete(string $name): void;
+}

--- a/src/SonsOfPHP/Component/Vault/Tests/VaultTest.php
+++ b/src/SonsOfPHP/Component/Vault/Tests/VaultTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SonsOfPHP\Component\Vault\Cipher\OpenSSLCipher;
+use SonsOfPHP\Component\Vault\Storage\InMemoryStorage;
+use SonsOfPHP\Component\Vault\Vault;
+
+/**
+ * @covers \SonsOfPHP\Component\Vault\Vault
+ * @internal
+ */
+class VaultTest extends TestCase
+{
+    /**
+     * Creates a vault instance for testing.
+     */
+    private function createVault(): Vault
+    {
+        $storage = new InMemoryStorage();
+        $cipher  = new OpenSSLCipher();
+        $key     = 'test_encryption_key_32_bytes!';
+
+        return new Vault($storage, $cipher, $key);
+    }
+
+    public function testSecretCanBeRetrieved(): void
+    {
+        $vault = $this->createVault();
+        $vault->set('db_password', 'secret');
+
+        $this->assertSame('secret', $vault->get('db_password'));
+    }
+
+    public function testGetReturnsNullWhenSecretIsMissing(): void
+    {
+        $vault = $this->createVault();
+
+        $this->assertNull($vault->get('missing'));
+    }
+
+    public function testSecretCanBeDeleted(): void
+    {
+        $vault = $this->createVault();
+        $vault->set('api_key', 'secret');
+        $vault->delete('api_key');
+
+        $this->assertNull($vault->get('api_key'));
+    }
+}

--- a/src/SonsOfPHP/Component/Vault/Vault.php
+++ b/src/SonsOfPHP/Component/Vault/Vault.php
@@ -4,43 +4,70 @@ declare(strict_types=1);
 
 namespace SonsOfPHP\Component\Vault;
 
+use RuntimeException;
 use SonsOfPHP\Component\Vault\Cipher\CipherInterface;
 use SonsOfPHP\Component\Vault\Storage\StorageInterface;
 
 /**
- * Vault stores encrypted secrets using a pluggable storage backend.
+ * Vault stores encrypted secrets using a pluggable storage backend with
+ * support for additional authenticated data and key rotation.
  */
 class Vault
 {
     /**
-     * @param StorageInterface $storage The storage backend.
-     * @param CipherInterface $cipher  The cipher used for encryption.
-     * @param string $encryptionKey The encryption key.
+     * @param StorageInterface       $storage       The storage backend.
+     * @param CipherInterface        $cipher        The cipher used for encryption.
+     * @param array<string,string>   $keys          Map of key IDs to encryption keys.
+     * @param string                 $currentKeyId  Identifier of the active key.
      */
-    public function __construct(private readonly StorageInterface $storage, private readonly CipherInterface $cipher, private readonly string $encryptionKey)
+    public function __construct(private readonly StorageInterface $storage, private readonly CipherInterface $cipher, private array $keys, private string $currentKeyId)
     {
     }
 
     /**
      * Stores a secret in the vault.
+     *
+     * @param string $name  Identifier of the secret.
+     * @param mixed  $secret The secret to store.
+     * @param string $aad   Additional authenticated data.
      */
-    public function set(string $name, string $secret): void
+    public function set(string $name, mixed $secret, string $aad = ''): void
     {
-        $encrypted = $this->cipher->encrypt($secret, $this->encryptionKey);
-        $this->storage->set($name, $encrypted);
+        $serialized = serialize($secret);
+        $key        = $this->keys[$this->currentKeyId];
+        $encrypted  = $this->cipher->encrypt($serialized, $key, $aad);
+        $this->storage->set($name, $this->currentKeyId . ':' . $encrypted);
     }
 
     /**
      * Retrieves a secret from the vault or null if it does not exist.
+     *
+     * @param string $name Identifier of the secret.
+     * @param string $aad  Additional authenticated data.
+     *
+     * @return mixed|null
      */
-    public function get(string $name): ?string
+    public function get(string $name, string $aad = ''): mixed
     {
-        $encrypted = $this->storage->get($name);
-        if (null === $encrypted) {
+        $record = $this->storage->get($name);
+        if (null === $record) {
             return null;
         }
 
-        return $this->cipher->decrypt($encrypted, $this->encryptionKey);
+        [$keyId, $ciphertext] = explode(':', $record, 2);
+        $key = $this->keys[$keyId] ?? null;
+        if (null === $key) {
+            throw new RuntimeException('Unknown key identifier.');
+        }
+
+        $serialized = $this->cipher->decrypt($ciphertext, $key, $aad);
+
+        $secret = @unserialize($serialized, ['allowed_classes' => false]);
+        if (false === $secret && 'b:0;' !== $serialized) {
+            throw new RuntimeException('Unable to unserialize secret.');
+        }
+
+        return $secret;
     }
 
     /**
@@ -49,5 +76,17 @@ class Vault
     public function delete(string $name): void
     {
         $this->storage->delete($name);
+    }
+
+    /**
+     * Rotates the active encryption key.
+     *
+     * @param string $keyId Identifier for the new key.
+     * @param string $key   The new encryption key.
+     */
+    public function rotateKey(string $keyId, string $key): void
+    {
+        $this->keys[$keyId] = $key;
+        $this->currentKeyId = $keyId;
     }
 }

--- a/src/SonsOfPHP/Component/Vault/Vault.php
+++ b/src/SonsOfPHP/Component/Vault/Vault.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Vault;
+
+use SonsOfPHP\Component\Vault\Cipher\CipherInterface;
+use SonsOfPHP\Component\Vault\Storage\StorageInterface;
+
+/**
+ * Vault stores encrypted secrets using a pluggable storage backend.
+ */
+class Vault
+{
+    /**
+     * @param StorageInterface $storage The storage backend.
+     * @param CipherInterface $cipher  The cipher used for encryption.
+     * @param string $encryptionKey The encryption key.
+     */
+    public function __construct(private readonly StorageInterface $storage, private readonly CipherInterface $cipher, private readonly string $encryptionKey)
+    {
+    }
+
+    /**
+     * Stores a secret in the vault.
+     */
+    public function set(string $name, string $secret): void
+    {
+        $encrypted = $this->cipher->encrypt($secret, $this->encryptionKey);
+        $this->storage->set($name, $encrypted);
+    }
+
+    /**
+     * Retrieves a secret from the vault or null if it does not exist.
+     */
+    public function get(string $name): ?string
+    {
+        $encrypted = $this->storage->get($name);
+        if (null === $encrypted) {
+            return null;
+        }
+
+        return $this->cipher->decrypt($encrypted, $this->encryptionKey);
+    }
+
+    /**
+     * Removes a secret from the vault.
+     */
+    public function delete(string $name): void
+    {
+        $this->storage->delete($name);
+    }
+}

--- a/src/SonsOfPHP/Component/Vault/composer.json
+++ b/src/SonsOfPHP/Component/Vault/composer.json
@@ -36,6 +36,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.3",
+        "ext-json": "*",
         "ext-openssl": "*"
     },
     "extra": {

--- a/src/SonsOfPHP/Component/Vault/composer.json
+++ b/src/SonsOfPHP/Component/Vault/composer.json
@@ -1,0 +1,57 @@
+{
+    "name": "sonsofphp/vault",
+    "type": "library",
+    "description": "Secure secret storage for PHP applications",
+    "keywords": [
+        "vault",
+        "secret",
+        "encryption"
+    ],
+    "homepage": "https://github.com/SonsOfPHP/vault",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sons of PHP Community",
+            "homepage": "https://github.com/SonsOfPHP/sonsofphp/graphs/contributors"
+        },
+        {
+            "name": "Joshua Estes",
+            "email": "joshua@sonsofphp.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/SonsOfPHP/sonsofphp/issues",
+        "forum": "https://github.com/orgs/SonsOfPHP/discussions",
+        "docs": "https://docs.sonsofphp.com"
+    },
+    "autoload": {
+        "psr-4": {
+            "SonsOfPHP\\Component\\Vault\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": ">=8.3",
+        "ext-openssl": "*"
+    },
+    "extra": {
+        "sort-packages": true,
+        "branch-alias": {
+            "dev-main": "0.3.x-dev"
+        }
+    },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/JoshuaEstes"
+        },
+        {
+            "type": "tidelift",
+            "url": "https://tidelift.com/subscription/pkg/packagist-sonsofphp-sonsofphp"
+        }
+    ]
+}

--- a/src/SonsOfPHP/Component/Vault/phpunit.xml.dist
+++ b/src/SonsOfPHP/Component/Vault/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+    backupGlobals="false"
+    colors="true"
+    bootstrap="vendor/autoload.php"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+
+  <php>
+    <ini name="error_reporting" value="-1" />
+  </php>
+
+    <testsuites>
+        <testsuite name="vault">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+  <source>
+      <include>
+          <directory>.</directory>
+      </include>
+      <exclude>
+          <directory>./Tests</directory>
+          <directory>./vendor</directory>
+      </exclude>
+  </source>
+</phpunit>


### PR DESCRIPTION
## Summary
- add Vault component with OpenSSL encryption and in-memory storage
- document Vault component and add package roadmap
- update repository roadmap and autoload mappings

## Testing
- `make php-cs-fixer`
- `make psalm` *(fails: Could not resolve config path to /workspace/sonsofphp/src/SonsOfPHP/Bundle/*/Tests)*
- `PHPUNIT_OPTIONS='src/SonsOfPHP/Component/Vault/Tests' make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1a90f6d0832ca625e694afc589a1